### PR TITLE
Change ROTATE_MAX_POSITION to 790

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/ClawSlide.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/ClawSlide.java
@@ -8,7 +8,7 @@ import org.firstinspires.ftc.teamcode.action.MotorPairAction;
 import org.firstinspires.ftc.teamcode.action.TimedAction;
 
 public class ClawSlide {
-    private static final int ROTATE_MAX_POSITION = 1000;
+    private static final int ROTATE_MAX_POSITION = 790;
     private static final int LIFT_MAX_POSITION = 2750;
     private static final double ROTATE_POWER = 0.5;
     private static final double LIFT_POWER = 1.0;


### PR DESCRIPTION
This is to prevent bashing of the claw when picking up a sample from the ground.

Before issuing a pull request, please see the contributing page.
